### PR TITLE
Add manifest support to the SFR

### DIFF
--- a/Documentation/framework.md
+++ b/Documentation/framework.md
@@ -58,6 +58,16 @@ OCP Security Workgroup
    <td>
    </td>
   </tr>
+  <tr>
+   <td>1.1
+   </td>
+   <td>October, 2024
+   </td>
+   <td>Rob Wood
+   </td>
+   <td>Add manifest support
+   </td>
+  </tr>
 </table>
 
 # Glossary

--- a/shortform_report-main/example_gen_sign_verify.py
+++ b/shortform_report-main/example_gen_sign_verify.py
@@ -8,6 +8,8 @@ Date:   June 5th, 2023
 from OcpReportLib import ShortFormReport
 import traceback
 import sys
+import json
+import hashlib
 
 
 # Hardcoding these is crude, but whatever, this is just an example script to
@@ -35,9 +37,36 @@ MY_KID = "Wile E Coyote"
 # Construct the short form report object
 rep = ShortFormReport()
 
+
+# XXX: Note to SRP: if this is a certification for a source code deliverable rather
+#      than a binary deliverable, then uncomment this section and provide the file
+#      input file generated as:
+#            "find . -type f -exec sha256sum {} \; > file_hashes.txt"
+# manifest = []
+# with open("file_hashes.txt") as hashfile:
+#     for line in hashfile:
+#         file_hash,file_name = line.split(" ",1)
+#         file_description = {}
+#         file_description["file_name"] = f"{file_name}".strip()
+#         file_description["file_hash"] = f"{file_hash}".strip()
+#         manifest.append(file_description)
+
+# sort list to make the diff easier later
+# manifest.sort( key=lambda x: x["file_name"] )
+# be as explicit about the JSON formatting as possible, so this validates later
+# m_str = json.dumps( manifest, sort_keys=False, separators=(',',':')).encode('utf-8')
+# compute manifest hashes
+# fw_hash_sha384 = hashlib.sha384( m_str, usedforsecurity=True ).hexdigest()
+# fw_hash_sha512 = hashlib.sha512( m_str, usedforsecurity=True ).hexdigest()
+# XXX
+
+
+
 # Add vendor device information
 # XXX: Note to SRP: This is where you must calculate the hash of the firmware 
 # image that you tested.
+fw_hash_sha384 = "cd484defa77e8c3e4a8dd73926e32365ea0dbd01e4eff017f211d4629cfcd8e4890dd66ab1bded9be865cd1c849800d4"
+fw_hash_sha512 = "84635baabc039a8c74aed163a8deceab8777fed32dc925a4a8dacfd478729a7b6ab1cb91d7d35b49e2bd007a80ae16f292be3ea2b9d9a88cb3cc8dff6a216988"
 rep.add_device(
     "ACME Inc",         # vendor name
     "Roadrunner Trap",  # product name
@@ -45,9 +74,10 @@ rep.add_device(
     "release_v1_2_3",   # repo tag
     "1.2.3",            # firmware version
     # fw_hash_sha384
-    "0xcd484defa77e8c3e4a8dd73926e32365ea0dbd01e4eff017f211d4629cfcd8e4890dd66ab1bded9be865cd1c849800d4",
+    fw_hash_sha384,
     # fw_hash_sha512
-    "0x84635baabc039a8c74aed163a8deceab8777fed32dc925a4a8dacfd478729a7b6ab1cb91d7d35b49e2bd007a80ae16f292be3ea2b9d9a88cb3cc8dff6a216988"
+    fw_hash_sha512
+    # manifest          # optional: comment if not using
 )
 
 # Add audit information from Security Review Provider information


### PR DESCRIPTION
Add manifest support to allow the SFR to cover deliverables with multiple files (such as source code bundles)

Improved error detection for missing and malformed hashes.