### PR TITLE
Add PEP8 formatting (auto-applied using Ruff). 

### DIFF
--- a/shortform_report-main/OcpReportLib.py
+++ b/shortform_report-main/OcpReportLib.py
@@ -10,7 +10,7 @@ More details about the OCP review framework can be found here:
 *  https://www.opencompute.org/wiki/Security
 
 For example usage of this script, refer to the following:
-  * example_generate.py: 
+  * example_generate.py:
       Demonstrates how to generate, sign and verify the JSON report.
   * sample_report.json
       An example JSON report that was created by this script.
@@ -28,14 +28,14 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 
 # Only the following JSON Web Algorithms (JWA) will be accepted by this script
-# for signing the short-form report. Refer to RFC7518 for more details. 
+# for signing the short-form report. Refer to RFC7518 for more details.
 ALLOWED_JWA_RSA_ALGOS = (
     "PS384",  # RSASSA-PSS using SHA-384 and MGF1 with SHA-384
     "PS512",  # RSASSA-PSS using SHA-512 and MGF1 with SHA-512
 )
 ALLOWED_JWA_ECDSA_ALGOS = (
     "ES384",  # ECDSA using P-384 and SHA-384
-    "ES512"  # ECDSA using P-521 and SHA-512
+    "ES512",  # ECDSA using P-521 and SHA-512
 )
 ALLOWED_JWA_ALGOS = ALLOWED_JWA_RSA_ALGOS + ALLOWED_JWA_ECDSA_ALGOS
 
@@ -43,7 +43,7 @@ ALLOWED_JWA_ALGOS = ALLOWED_JWA_RSA_ALGOS + ALLOWED_JWA_ECDSA_ALGOS
 # signing a short-form report.
 ALLOWED_RSA_KEY_SIZES = (
     3072,  # RSA 384
-    4096  # RSA 512
+    4096,  # RSA 512
 )
 
 
@@ -53,23 +53,32 @@ class ShortFormReport(object):
         self.report["review_framework_version"] = f"{framework_ver}".strip()
         self.signed_report = None
 
-    def add_device(self, vendor: str, product: str, category: str, repo_tag: str, fw_ver: str, fw_hash_sha384: str,
-                   fw_hash_sha512: str, manifest: str = None) -> None:
+    def add_device(
+        self,
+        vendor: str,
+        product: str,
+        category: str,
+        repo_tag: str,
+        fw_ver: str,
+        fw_hash_sha384: str,
+        fw_hash_sha512: str,
+        manifest: str = None,
+    ) -> None:
         """Add metadata that describes the vendor's device that was tested.
 
         vendor:    The name of the vendor that manufactured the device.
         product:   The name of the device. Usually a model name or number.
-        category:  The type of device that was audited. Usually a short string 
+        category:  The type of device that was audited. Usually a short string
                      such as: 'storage', 'network', 'gpu', 'cpu', 'apu', or 'bmc'.
         repo_tag:  The Git repository tag associated with the audit. Useful when
-                     evaluating ROMs for which we cannot easily calculate or 
+                     evaluating ROMs for which we cannot easily calculate or
                      verify the hash.
         fw_ver:    The version of the firmware image that is attested by this
                      report. In most cases this will be the firmware version
                      produced by the vendor after the security audit completes,
                      which contains fixes for all vulnerabilities found during
                      the audit.
-        fw_hash_sha384: A hex-encoded string containing the SHA2-384 hash of 
+        fw_hash_sha384: A hex-encoded string containing the SHA2-384 hash of
                         the firmware image. Prefixed with "0x".
         fw_hash_sha512: ... ditto but using SHA2-512 ...
         """
@@ -84,13 +93,21 @@ class ShortFormReport(object):
         if manifest is not None:
             self.report["device"]["manifest"] = manifest
 
-    def add_audit(self, srp: str, methodology: str, date: str, report_ver: str, scope_number: int, cvss_ver: str = "3.1") -> None:
+    def add_audit(
+        self,
+        srp: str,
+        methodology: str,
+        date: str,
+        report_ver: str,
+        scope_number: int,
+        cvss_ver: str = "3.1",
+    ) -> None:
         """Add metadata that describes the scope of the security review.
 
         srp:         The name of the Security Review Provider.
         methodology: The test methodology. Currently a free-form text field.
                        Usually a value like 'whitebox' or 'blackbox'.
-        date:        The date when the security audit completed. In the 
+        date:        The date when the security audit completed. In the
                        YYYY-MM-DD format.
         report_ver:  Version of the report created by the SRP.
         scope:       The OCP scope number of the audit, 1, 2, or 3.
@@ -106,13 +123,21 @@ class ShortFormReport(object):
         self.report["audit"]["cvss_version"] = f"{cvss_ver}".strip()
         self.report["audit"]["issues"] = []
 
-    def add_issue(self, title: str, cvss_score: str, cvss_vec: str, cwe: str, description: str, cve=None) -> None:
+    def add_issue(
+        self,
+        title: str,
+        cvss_score: str,
+        cvss_vec: str,
+        cwe: str,
+        description: str,
+        cve=None,
+    ) -> None:
         """Add one issue to the list of issues. This list should only contain
         unfixed issues. That is, any vulnerabilities discovered during the
         audit that were fixed before the 'fw_version' (listed above) should not
         be included.
 
-        title:       A brief summary of the issue. Usually taken directly from 
+        title:       A brief summary of the issue. Usually taken directly from
                        the SRP's audit report.
         cvss_score:  The CVSS base score, represented as a string, such as "7.1".
         cvss_vec:    The CVSS base vector. Temporal and environmental metrics are
@@ -143,18 +168,15 @@ class ShortFormReport(object):
     ###########################################################################
 
     def get_report_as_dict(self) -> dict:
-        """Returns the short-form report as a Python dict.
-        """
+        """Returns the short-form report as a Python dict."""
         return self.report
 
     def get_report_as_str(self) -> str:
-        """Return the short-form report as a formatted and indented string.
-        """
+        """Return the short-form report as a formatted and indented string."""
         return json.dumps(self.get_report_as_dict(), indent=4)
 
     def print_report(self) -> None:
-        """Pretty-prints the short-form report
-        """
+        """Pretty-prints the short-form report"""
         print(self.get_report_as_str())
 
     ###########################################################################
@@ -182,11 +204,15 @@ class ShortFormReport(object):
             return False
 
         # Parse the private key to do some simple validation
-        pem = serialization.load_pem_private_key(priv_key, None, backend=default_backend())
+        pem = serialization.load_pem_private_key(
+            priv_key, None, backend=default_backend()
+        )
 
         # Ensure the correct private key types are passed
         if not isinstance(pem, (RSAPrivateKey, EllipticCurvePrivateKey)):
-            print(f"Expected 'priv_key' to be a 'RSAPrivateKey' or 'EllipticCurvePrivateKey'")
+            print(
+                "Expected 'priv_key' to be a 'RSAPrivateKey' or 'EllipticCurvePrivateKey'"
+            )
             return False
 
         # Sanity check which curve is in use:
@@ -200,14 +226,18 @@ class ShortFormReport(object):
         # RSA keys smaller than 3072 bytes.
         if algo in ALLOWED_JWA_RSA_ALGOS:
             if pem.key_size not in ALLOWED_RSA_KEY_SIZES:
-                print(f"RSA key is too small: {pem.key_size}, must be one of: {ALLOWED_RSA_KEY_SIZES}")
+                print(
+                    f"RSA key is too small: {pem.key_size}, must be one of: {ALLOWED_RSA_KEY_SIZES}"
+                )
                 return False
 
         # Ensure the provided private key corresponds with the specified algo parameter.
-        if ((algo == "PS384") and (pem.key_size != 3072)) or \
-                ((algo == "PS512") and (pem.key_size != 4096)) or \
-                ((algo == "ES384") and (pem.key_size != 384)) or \
-                ((algo == "ES512") and (pem.key_size != 521)):
+        if (
+            ((algo == "PS384") and (pem.key_size != 3072))
+            or ((algo == "PS512") and (pem.key_size != 4096))
+            or ((algo == "ES384") and (pem.key_size != 384))
+            or ((algo == "ES512") and (pem.key_size != 521))
+        ):
             print(f"Mismatch between algo={algo} and private key size: {pem.key_size}")
             return False
 
@@ -215,10 +245,9 @@ class ShortFormReport(object):
         jws_headers = {"kid": f"{kid}"}
 
         # Finally, we can sign the short-form report.
-        self.signed_report = jwt.encode(self.get_report_as_dict(),
-                                        key=priv_key,
-                                        algorithm=algo,
-                                        headers=jws_headers)
+        self.signed_report = jwt.encode(
+            self.get_report_as_dict(), key=priv_key, algorithm=algo, headers=jws_headers
+        )
         return True
 
     def get_signed_report(self) -> bytes:
@@ -233,10 +262,10 @@ class ShortFormReport(object):
 
     def get_signed_report_kid(self, signed_report: bytes) -> str:
         """Read the unverified JWS header to extract the Key ID. This will be
-        used to find the appropriate public key for verifying the report 
+        used to find the appropriate public key for verifying the report
         signature.
 
-        signed_report: A bytes object containing the signed report as a JWS 
+        signed_report: A bytes object containing the signed report as a JWS
                          object.
 
         Returns None if the 'kid' isn't present, otherwise return the 'kid' string.
@@ -248,44 +277,65 @@ class ShortFormReport(object):
     def verify_signed_report(self, signed_report: bytes, pub_key: bytes) -> dict:
         """Verify the signed report using the provided public key.
 
-        signed_report: A bytes object containing the signed report as a JWS 
+        signed_report: A bytes object containing the signed report as a JWS
                          object.
         pub_key:       A bytes object containing the public key used to verify
                          the signed report, which corresponds to the SRP's 'kid'.
 
-        Returns a dictionary containing the decoded JSON short-form report 
+        Returns a dictionary containing the decoded JSON short-form report
         payload.
         """
-        decoded = jwt.decode(signed_report,
-                             pub_key,
-                             algorithms=ALLOWED_JWA_ALGOS)
+        decoded = jwt.decode(signed_report, pub_key, algorithms=ALLOWED_JWA_ALGOS)
 
         # At least one of the hashes must be present for this JSON to be valid.
-        if "fw_hash_sha2_384" not in decoded["device"] and "fw_hash_sha2_512" not in decoded["device"]:
+        if (
+            "fw_hash_sha2_384" not in decoded["device"]
+            and "fw_hash_sha2_512" not in decoded["device"]
+        ):
             # Suppress this error for the one report that has no hash:
             # https://github.com/opencomputeproject/OCP-Security-SAFE/blob/main/Reports/CHIPS_Alliance/2023/Caliptra/OCP_SAFE_-_caliptra_-_ROM.json
             if decoded["device"]["repo_tag"] != "release_v20231014_0":
-                raise Exception ("Neither fw_hash_sha2 is present!")
+                raise Exception("Neither fw_hash_sha2 is present!")
 
         # Validate hash lengths are correct
-        if "fw_hash_sha2_384" in decoded["device"] and len(decoded["device"]["fw_hash_sha2_384"]) != hashlib.sha384().digest_size*2:
-            l=len(decoded['device']['fw_hash_sha2_384'])
-            raise Exception (f"fw_hash_sha2_384 hash digest length must be {hashlib.sha384().digest_size*2} (found {l})!")
-        if "fw_hash_sha2_512" in decoded["device"] and len(decoded["device"]["fw_hash_sha2_512"]) != hashlib.sha512().digest_size*2:
-            l=len(decoded['device']['fw_hash_sha2_512'])
-            raise Exception (f"fw_hash_sha2_512 hash digest length must be {hashlib.sha512().digest_size*2} (found {l})!")
+        if (
+            "fw_hash_sha2_384" in decoded["device"]
+            and len(decoded["device"]["fw_hash_sha2_384"])
+            != hashlib.sha384().digest_size * 2
+        ):
+            l3 = len(decoded["device"]["fw_hash_sha2_384"])
+            raise Exception(
+                f"fw_hash_sha2_384 hash digest length must be {hashlib.sha384().digest_size*2} (found {l3})!"
+            )
+        if (
+            "fw_hash_sha2_512" in decoded["device"]
+            and len(decoded["device"]["fw_hash_sha2_512"])
+            != hashlib.sha512().digest_size * 2
+        ):
+            l5 = len(decoded["device"]["fw_hash_sha2_512"])
+            raise Exception(
+                f"fw_hash_sha2_512 hash digest length must be {hashlib.sha512().digest_size*2} (found {l5})!"
+            )
 
         # if there is a manifest list, then validate its hash(es)
         if "manifest" in decoded["device"]:
             # be as explicit about the JSON formatting as possible
-            m_str = json.dumps( decoded["device"]["manifest"], sort_keys=False, separators=(',',':')).encode('utf-8')
-            fw_hash_sha384 = hashlib.sha384( m_str, usedforsecurity=True ).hexdigest()
-            fw_hash_sha512 = hashlib.sha512( m_str, usedforsecurity=True ).hexdigest()
+            m_str = json.dumps(
+                decoded["device"]["manifest"], sort_keys=False, separators=(",", ":")
+            ).encode("utf-8")
+            fw_hash_sha384 = hashlib.sha384(m_str, usedforsecurity=True).hexdigest()
+            fw_hash_sha512 = hashlib.sha512(m_str, usedforsecurity=True).hexdigest()
 
-            if "fw_hash_sha2_384" in decoded["device"] and decoded["device"]["fw_hash_sha2_384"] != fw_hash_sha384:
-                raise Exception ("fw_hash_sha2_384 does not match manifest's hash!")
+            if (
+                "fw_hash_sha2_384" in decoded["device"]
+                and decoded["device"]["fw_hash_sha2_384"] != fw_hash_sha384
+            ):
+                raise Exception("fw_hash_sha2_384 does not match manifest's hash!")
 
-            if "fw_hash_sha2_512" in decoded["device"] and decoded["device"]["fw_hash_sha2_512"] != fw_hash_sha512:
-                raise Exception ("fw_hash_sha2_512 does not match manifest's hash!")
+            if (
+                "fw_hash_sha2_512" in decoded["device"]
+                and decoded["device"]["fw_hash_sha2_512"] != fw_hash_sha512
+            ):
+                raise Exception("fw_hash_sha2_512 does not match manifest's hash!")
 
         return decoded


### PR DESCRIPTION
PEP8 formatting makes integration with other projects that use this easier as merges from the upstream OCP repo will be much cleaner.

This change has no functional effects.